### PR TITLE
Jest設定の更新、CLI引数テストの強化、およびHusky設定の修正

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run check

--- a/bin/web-link-collector.ts
+++ b/bin/web-link-collector.ts
@@ -67,12 +67,19 @@ const main = async () => {
     // Parse filters if provided as a JSON string
     let filters: FilterConditions | undefined;
     if (mergedConfig.filters) {
-      try {
-        filters = JSON.parse(mergedConfig.filters);
-      } catch (error) {
-        logger.error(
-          `Invalid JSON format for filters: ${error instanceof Error ? error.message : String(error)}`
-        );
+      if (typeof mergedConfig.filters === 'string') {
+        try {
+          filters = JSON.parse(mergedConfig.filters);
+        } catch (error) {
+          logger.error(
+            `Invalid JSON format for filters: ${error instanceof Error ? error.message : String(error)}`
+          );
+          process.exit(1);
+        }
+      } else if (typeof mergedConfig.filters === 'object') {
+        filters = mergedConfig.filters as FilterConditions;
+      } else {
+        logger.error(`Invalid type for filters: Expected a JSON string or an object.`);
         process.exit(1);
       }
     }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,12 @@
-export default {
-  preset: 'ts-jest/presets/js-with-ts-esm',
+module.exports = {
+  preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        useESM: true,
+        useESM: false,
       },
     ],
   },
@@ -14,5 +14,4 @@ export default {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
-  extensionsToTreatAsEsm: ['.ts'],
 };

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -13,6 +13,9 @@ import { loadConfig } from './configLoader';
  * @returns Promise resolving to the parsed arguments
  */
 export const parseCliArgs = async (): Promise<any> => {
+  // テスト環境ではprocess.exitを呼び出さないように設定
+  const exitProcess = process.env.NODE_ENV === 'test' ? false : true;
+
   return yargs(hideBin(process.argv))
     .scriptName('web-link-collector')
     .usage('Usage: $0 --initialUrl <url> [options]')
@@ -94,5 +97,6 @@ export const parseCliArgs = async (): Promise<any> => {
     .epilogue('For more information, see the documentation')
     .help()
     .alias('help', 'h')
+    .exitProcess(exitProcess) // テスト環境ではプロセスを終了しない
     .parse();
 };

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -63,8 +63,14 @@ export const collectWebLinks = async (params: InitialUrlParams): Promise<Collect
     visitedUrls.add(url);
     stats.totalUrlsScanned++;
 
-    // Add to collected URLs if it passes the filter
-    if (isUrlAllowed(url, filters)) {
+    // Add to collected URLs if it passes the filter OR if it's the initial URL (depth 0)
+    let allowedByFilter = true;
+    if (currentDepth > 0) {
+      // Only apply filter if not the initial URL
+      allowedByFilter = isUrlAllowed(url, filters);
+    }
+
+    if (allowedByFilter) {
       allCollectedUrls.add(url);
       stats.totalUrlsCollected++;
 
@@ -82,7 +88,7 @@ export const collectWebLinks = async (params: InitialUrlParams): Promise<Collect
       }
     } else {
       logger.debug(`URL filtered out: ${url}`);
-      return;
+      return; // Do not proceed if filtered out and not initial URL
     }
 
     // Stop recursion if we've reached the maximum depth

--- a/tests/cli/args.test.ts
+++ b/tests/cli/args.test.ts
@@ -1,33 +1,150 @@
 /**
- * Simplified tests for CLI argument parsing
+ * Tests for CLI argument parsing using yargs.
  */
 
 import { parseCliArgs } from '../../src/cli/args';
-import { jest, describe, it, expect } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import * as configLoader from '../../src/cli/configLoader';
 
-// Mock the parseCliArgs function to bypass yargs
-jest.mock('../../src/cli/args', () => ({
-  parseCliArgs: jest.fn().mockImplementation(() => {
-    return Promise.resolve({
-      initialUrl: 'https://example.com',
-      depth: 2,
-      logLevel: 'info',
-      format: 'json',
-      delayMs: 1000,
+// Helper function to simulate process.argv
+const mockProcessArgv = (args: string[]) => {
+  const originalArgv = process.argv;
+  Object.defineProperty(process, 'argv', {
+    value: ['node', 'web-link-collector', ...args],
+    configurable: true,
+  });
+
+  // 後で元に戻せるようにするための関数を返す
+  return () => {
+    Object.defineProperty(process, 'argv', {
+      value: originalArgv,
+      configurable: true,
     });
-  }),
-}));
+  };
+};
+
+// Mock console.error to capture error messages from yargs
+const mockConsoleError = (): jest.Mock => {
+  return jest.spyOn(console, 'error').mockImplementation(jest.fn()) as jest.Mock;
+};
 
 describe('parseCliArgs', () => {
-  it('returns parsed arguments', async () => {
-    const args = await parseCliArgs();
+  let restoreArgv: () => void;
+  let loadConfigSpy: any;
+  let originalNodeEnv: string | undefined;
 
-    expect(args).toEqual({
-      initialUrl: 'https://example.com',
+  beforeEach(() => {
+    // テスト環境であることを設定
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test';
+
+    // Reset mocks for each test
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+
+    // Suppress error output
+    mockConsoleError();
+
+    // モックの設定
+    loadConfigSpy = jest.spyOn(configLoader, 'loadConfig').mockImplementation(async () => ({}));
+  });
+
+  afterEach(() => {
+    // テスト後に元のprocess.argvを復元
+    if (restoreArgv) {
+      restoreArgv();
+    }
+
+    // 環境変数を元に戻す
+    process.env.NODE_ENV = originalNodeEnv;
+
+    // スパイの復元
+    loadConfigSpy.mockRestore();
+  });
+
+  it('should parse the initialUrl argument correctly', async () => {
+    restoreArgv = mockProcessArgv(['--initialUrl', 'https://example.com']);
+    const args = await parseCliArgs();
+    expect(args.initialUrl).toBe('https://example.com');
+  });
+
+  it('should parse optional arguments correctly', async () => {
+    restoreArgv = mockProcessArgv([
+      '--initialUrl',
+      'https://example.com',
+      '--depth',
+      '3',
+      '--format',
+      'txt',
+      '--output',
+      'results.txt',
+      '--selector',
+      '.content a',
+      '--delayMs',
+      '500',
+      '--logLevel',
+      'debug',
+      '--filters',
+      '{"include":["test"]}',
+    ]);
+    const args = await parseCliArgs();
+    expect(args.depth).toBe(3);
+    expect(args.format).toBe('txt');
+    expect(args.output).toBe('results.txt');
+    expect(args.filters).toBe('{"include":["test"]}');
+    expect(args.selector).toBe('.content a');
+    expect(args.delayMs).toBe(500);
+    expect(args.logLevel).toBe('debug');
+  });
+
+  it('should use default values for optional arguments if not provided', async () => {
+    restoreArgv = mockProcessArgv(['--initialUrl', 'https://example.com']);
+    const args = await parseCliArgs();
+    expect(args.depth).toBe(1); // Default depth
+    expect(args.format).toBe('json'); // Default format
+    expect(args.logLevel).toBe('info'); // Default logLevel
+    expect(args.delayMs).toBe(1000); // Default delayMs
+  });
+
+  it('should throw an error if initialUrl is missing', async () => {
+    restoreArgv = mockProcessArgv([]);
+    await expect(parseCliArgs()).rejects.toThrow('initialUrl is required');
+  });
+
+  it('should handle invalid depth value', async () => {
+    restoreArgv = mockProcessArgv(['--initialUrl', 'https://example.com', '--depth', '10']);
+    await expect(parseCliArgs()).rejects.toThrow();
+  });
+
+  it('should handle invalid format value', async () => {
+    restoreArgv = mockProcessArgv(['--initialUrl', 'https://example.com', '--format', 'invalid']);
+    await expect(parseCliArgs()).rejects.toThrow();
+  });
+
+  it('should handle invalid logLevel value', async () => {
+    restoreArgv = mockProcessArgv(['--initialUrl', 'https://example.com', '--logLevel', 'invalid']);
+    await expect(parseCliArgs()).rejects.toThrow();
+  });
+
+  it('should load config from file when configFile is provided', async () => {
+    const mockConfig = {
+      initialUrl: 'https://example-from-config.com',
       depth: 2,
-      logLevel: 'info',
-      format: 'json',
-      delayMs: 1000,
-    });
+    };
+    loadConfigSpy.mockResolvedValue(mockConfig);
+
+    restoreArgv = mockProcessArgv(['--configFile', 'config.test.yaml']);
+    const args = await parseCliArgs();
+    expect(loadConfigSpy).toHaveBeenCalledWith('config.test.yaml');
+    // 設定ファイルの値はparse関数の返り値には含まれない（実際のマージはconfigLoader.mergeConfigで行われる）
+    // ここではconfigFileパラメータが正しく設定されることだけを確認する
+    expect(args.configFile).toBe('config.test.yaml');
+  });
+
+  it('should handle config file loading errors', async () => {
+    loadConfigSpy.mockRejectedValue(new Error('File not found'));
+
+    restoreArgv = mockProcessArgv(['--configFile', 'nonexistent.yaml']);
+    await expect(parseCliArgs()).rejects.toThrow('Error loading config file');
   });
 });

--- a/tests/filter.test.ts
+++ b/tests/filter.test.ts
@@ -1,11 +1,11 @@
 /**
- * Tests for the URL filtering module
+ * Tests for the URL filtering functionality.
+ * Focus on core filter functionality without dependencies on specific configuration values.
  */
 
-const { isUrlAllowed } = require('../src/filter');
-// Removing unused import
-// const { FilterConditions } = require('../src/types');
-const { describe, it, expect } = require('@jest/globals');
+import { isUrlAllowed } from '../src/filter';
+import { FilterConditions } from '../src/types';
+import { describe, it, expect } from '@jest/globals';
 
 describe('isUrlAllowed', () => {
   it('allows URL if no filters are provided (excluding common paths)', () => {
@@ -98,5 +98,30 @@ describe('isUrlAllowed', () => {
     expect(isUrlAllowed('http://test.org/any-page', filters)).toBe(true);
     expect(isUrlAllowed('http://example.com/about', filters)).toBe(false);
     expect(isUrlAllowed('http://othersite.com/page', filters)).toBe(false);
+  });
+
+  it('should correctly handle default excluded paths', () => {
+    const filters: FilterConditions = [{ domain: 'example.com' }]; // No specific path filter
+    expect(isUrlAllowed('https://example.com/admin', filters)).toBe(false);
+    expect(isUrlAllowed('https://example.com/wp-login.php', filters)).toBe(false);
+    expect(isUrlAllowed('https://example.com/cart/items', filters)).toBe(false);
+    expect(isUrlAllowed('https://example.com/some/path', filters)).toBe(true);
+  });
+
+  // 様々なURLパスに対するパスプレフィックスフィルターの一般的なテスト
+  it('correctly applies pathPrefix filtering for various URL structures', () => {
+    // 先頭が完全一致するケース
+    const exactPrefixFilters: FilterConditions = [{ pathPrefix: '/test/path/' }];
+    expect(isUrlAllowed('https://example.com/test/path/page', exactPrefixFilters)).toBe(true);
+    expect(isUrlAllowed('https://example.com/another/test/path/', exactPrefixFilters)).toBe(false);
+
+    // 大文字小文字の区別
+    const caseSensitiveFilters: FilterConditions = [{ pathPrefix: '/Case/Sensitive/' }];
+    expect(isUrlAllowed('https://example.com/Case/Sensitive/page', caseSensitiveFilters)).toBe(
+      true
+    );
+    expect(isUrlAllowed('https://example.com/case/sensitive/page', caseSensitiveFilters)).toBe(
+      false
+    );
   });
 });


### PR DESCRIPTION
## PRの概要
このプルリクエストは、Jestテスト設定の更新、コマンドラインインターフェース（CLI）の引数解析に関するテストケースの大幅な拡充、およびHuskyのGitフックスクリプトにおける設定警告の修正を含みます。また、CLIにおけるフィルター処理やURL収集時のフィルタリングロジックにも若干の改善が加えられています。

## 変更点
- Huskyの`pre-commit`および`pre-push`スクリプトから、`husky.sh`の読み込みとshebangが削除され、設定警告が解消されました。
- CLIのメイン処理（`bin/web-link-collector.ts`）において、`filters`引数の処理が改善され、JSON文字列形式とオブジェクト形式の両方を受け付けるようになりました。
- Jestの設定ファイル（`jest.config.js`）が更新され、エクスポート形式の変更、プリセットの変更、ESM関連設定の調整が行われました。
- CLI引数解析処理（`src/cli/args.ts`）において、テスト実行環境ではyargsによるプロセスの自動終了を無効にする設定が追加されました。
- URL収集処理（`src/collector.ts`）において、フィルタリングロジックが変更され、収集深度0（初期URL）のURLにはフィルターを適用せず、それ以降の深度で収集されたURLに対してのみフィルターが適用されるようになりました。
- CLI引数解析に関するテスト（`tests/cli/args.test.ts`）が全面的に刷新され、`process.argv`や`console.error`のモック、`configLoader`のスパイを利用したより詳細なテストケースが追加されました。必須引数、オプション引数、デフォルト値、エラーケース、設定ファイル読み込みなど、多岐にわたる検証が行われるようになりました。
- URLフィルタリングに関するテスト（`tests/filter.test.ts`）が更新され、デフォルト除外パスや様々なパスプレフィックスに対するテストケースが追加されました。
