### PR TITLE
共通ルール定義、リンク抽出ロジック改善、ドキュメント更新

### DIFF
--- a/.cursor/rules/common.mdc
+++ b/.cursor/rules/common.mdc
@@ -1,0 +1,37 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# WebLinkCollector project common rules
+
+## Test-related
+- Test coverage should be maintained above 91%.
+- Appropriate mocking and timer handling for testing asynchronous processes
+- Ensure that ESLint checks are passed before running tests
+
+## Coding style
+- Prefix unused arguments and variables with `_` (e.g. `_message`, `_args`)
+- Do not leave console output (console.log, console.error, etc.) in production code
+- Use logger interfaces to log output at the appropriate log level.
+
+## URL processing
+- Appropriate exclusion of URLs contained within query parameters and hash fragments
+- Handle social media share links (Twitter, Facebook, etc.) with special care.
+- Explicit URL condition filtering using the `FilterConditions` type.
+- Always exclude administrative paths defined in DEFAULT_EXCLUDED_PATHS.
+
+## Error handling
+- Use try-catch syntax and catch and log errors appropriately.
+- Exceptions such as URL parsing failures should be handled explicitly and a default safe behaviour defined.
+
+## Performance considerations
+- When processing large numbers of URLs, set appropriate delays and take rate limits into account.
+- Be aware of memory usage and process large HTML strings efficiently.
+
+## Code quality
+- Ensure Husky pre-commit hooks are passed before pull requests
+- When adding new functionality, be sure to add corresponding test cases
+- Make sure all existing tests pass after refactoring
+
+Translated with www.DeepL.com/Translator (free version)

--- a/.cursor/rules/common.mdc
+++ b/.cursor/rules/common.mdc
@@ -34,4 +34,21 @@ alwaysApply: true
 - When adding new functionality, be sure to add corresponding test cases
 - Make sure all existing tests pass after refactoring
 
-Translated with www.DeepL.com/Translator (free version)
+## Logging
+- Always use the logger interface instead of direct console output in production code
+- Use null-object pattern for dummy loggers rather than wrapping console methods
+- Ensure log messages are consistent and include proper context (e.g. URL, timestamp, request ID)
+- Log levels should be appropriately assigned based on message importance
+
+## Testing
+- When using Jest's fake timers, ensure proper handling of Promise-based code:
+  - Use jest.runAllTimers() after advancing time
+  - Wait for all promises to resolve/flush before assertions
+  - Consider using jest.advanceTimersToNextTimer() for complex timing scenarios
+- Mock objects should follow the same interface patterns as real implementations
+- Test error conditions with appropriate mocks rather than triggering real errors
+
+## Documentation
+- Document rate limiting strategies and parameters
+- Include inline documentation for complex asynchronous flows
+- Add JSDoc for all exported functions and classes with proper parameter and return type documentation

--- a/README-ja.md
+++ b/README-ja.md
@@ -1,0 +1,257 @@
+# WebLinkCollector
+
+[English](./README.md) | 日本語
+
+Webページから再帰的にリンクを収集し、構造化データとして出力するライブラリおよびCLIツールです。
+
+## 特徴
+
+- 設定可能な深さまで再帰的にWebページをクロール（最大5階層）
+- CSSセレクタを使用したHTML内のリンク抽出
+- ドメイン、パスプレフィックス、正規表現パターン、キーワードによるURL絞り込み
+- クエリパラメータやハッシュフラグメント内のURL除外機能
+- JSON または プレーンテキスト形式での結果出力
+- 設定可能なログレベルとリクエスト間隔
+- JSON/YAMLファイルを用いた構成のサポート
+
+## インストール
+
+### グローバルインストール
+
+```bash
+npm install -g web-link-collector
+```
+
+### ローカルインストール
+
+```bash
+npm install web-link-collector
+```
+
+### 開発環境セットアップ
+
+リポジトリをクローンして依存関係をインストール：
+
+```bash
+git clone https://github.com/yourusername/web-link-collector.git
+cd web-link-collector
+npm install
+```
+
+リントの実行：
+
+```bash
+npm run lint
+```
+
+テストの実行：
+
+```bash
+npm run test
+```
+
+プロジェクトのビルド：
+
+```bash
+npm run build
+```
+
+#### 利用可能なスクリプト
+
+| スクリプト          | 説明                                   |
+| ------------------- | -------------------------------------- |
+| `npm run build`     | TypeScriptをJavaScriptにコンパイル     |
+| `npm run test`      | すべてのテストを実行                   |
+| `npm run test:core` | コア機能のテストを実行（`test`と同じ） |
+| `npm run lint`      | リントの問題をチェック                 |
+| `npm run lint:fix`  | リントの問題を自動修正                 |
+| `npm run format`    | Prettierでコードをフォーマット         |
+| `npm run check`     | リントとテストを実行                   |
+| `npm run start`     | CLIツールを実行                        |
+
+#### Gitフック
+
+このプロジェクトはHuskyを使用してコード品質を強制し、以下のgitフックを実装しています：
+
+- **pre-commit**: ステージングしたファイルに対してリント、フォーマット、テストを実行
+- **pre-push**: 変更をプッシュする前にすべてのリントとテストが通ることを確認
+
+## CLI使用方法
+
+CLIツールの基本的な使用方法：
+
+```bash
+web-link-collector --initialUrl https://example.com --depth 2
+```
+
+### CLIオプション
+
+| オプション      | 説明                                                  | デフォルト |
+| --------------- | ----------------------------------------------------- | ---------- |
+| `--initialUrl`  | リンク収集の開始URL                                   | _必須_     |
+| `--depth`       | 最大再帰深度 (0-5)                                    | 1          |
+| `--filters`     | フィルタ条件のJSON文字列                              | なし       |
+| `--filtersFile` | フィルタ条件を含むJSONまたはYAMLファイルへのパス      | なし       |
+| `--selector`    | リンク抽出範囲を制限するCSSセレクタ（初期ページのみ） | なし       |
+| `--delayMs`     | リクエスト間の遅延（ミリ秒）                          | 1000       |
+| `--logLevel`    | ログレベル (debug, info, warn, error, none)           | info       |
+| `--output`      | 出力ファイルパス（指定されない場合、標準出力へ出力）  | なし       |
+| `--format`      | 出力形式 (json, txt)                                  | json       |
+| `--configFile`  | JSONまたはYAML設定ファイルへのパス                    | なし       |
+| `--skipQuery`   | クエリパラメータ内のURLをスキップ                     | true       |
+| `--skipHash`    | ハッシュフラグメント内のURLをスキップ                 | true       |
+| `--help`, `-h`  | ヘルプメッセージを表示                                | -          |
+
+### 使用例
+
+再帰深度2でウェブサイトからリンクを収集：
+
+```bash
+web-link-collector --initialUrl https://example.com --depth 2
+```
+
+指定したドメインからのリンクのみを収集：
+
+```bash
+web-link-collector --initialUrl https://example.com --filters '{"domain": "example.com"}'
+```
+
+初期ページの特定セクションからのリンク抽出に制限：
+
+```bash
+web-link-collector --initialUrl https://example.com --selector ".main-content a"
+```
+
+結果をテキストファイルに出力：
+
+```bash
+web-link-collector --initialUrl https://example.com --output results.txt --format txt
+```
+
+クエリパラメータ内のURLのスキップを無効化：
+
+```bash
+web-link-collector --initialUrl https://example.com --skipQuery false
+```
+
+設定ファイルを使用：
+
+```bash
+web-link-collector --configFile config.yaml
+```
+
+## ライブラリ使用方法
+
+WebLinkCollectorをNode.jsアプリケーション内でライブラリとして使用することもできます：
+
+```javascript
+import { collectLinks } from 'web-link-collector';
+
+// 基本的な使用方法
+const results = await collectLinks('https://example.com', {
+  depth: 2,
+});
+
+console.log(results);
+
+// より多くのオプションを指定
+const results = await collectLinks('https://example.com', {
+  depth: 2,
+  filters: [{ domain: 'example.com' }, { domain: 'api.example.com' }],
+  selector: '.main-content a',
+  delayMs: 2000,
+  logLevel: 'info',
+  skipQueryUrls: true, // クエリパラメータ内のURLをスキップ
+  skipHashUrls: true, // ハッシュフラグメント内のURLをスキップ
+});
+
+// 結果へのアクセス
+console.log(`収集したURL総数: ${results.allCollectedUrls.length}`);
+console.log(`見つかったリンク関係: ${results.linkRelationships.length}`);
+console.log(`発生したエラー: ${results.errors.length}`);
+console.log(`実行時間: ${results.stats.durationMs}ms`);
+```
+
+## 設定ファイル
+
+JSONまたはYAML設定ファイルを使用してオプションを指定できます。以下は例です：
+
+```yaml
+initialUrl: https://example.com
+depth: 2
+delayMs: 2000
+logLevel: info
+format: json
+
+# 初期ページでのリンク抽出を制限するCSSセレクタ
+selector: '.main-content a'
+
+# クエリパラメータやハッシュ内のURLのスキップ設定
+skipQueryUrls: true
+skipHashUrls: true
+
+# フィルタは収集するURLを定義します
+filters:
+  # 最初のフィルタ条件（フィルタオブジェクト間はOR論理）
+  - domain: example.com
+    pathPrefix: /blog
+
+  # 2番目のフィルタ条件
+  - domain: api.example.com
+```
+
+### 設定ファイルに関する重要な注意点
+
+1. **YAML特殊文字**: YAMLで特殊文字（`#`、`:`など）を使用する場合、値を引用符で囲む必要があります。例えば、`selector: #main`ではなく`selector: "#main"`を使用します。
+
+2. **CLIと設定の優先順位**: CLIオプションと設定ファイルの両方が提供される場合、CLIオプションが優先されます。明示的に指定されたCLIオプションのみが設定ファイルの値を上書きします。
+
+3. **セレクタの動作**: CSSセレクタは初期ページ（深度0）でのリンク抽出にのみ適用されます。それ以降のページではセレクタに関係なくすべてのリンクが抽出されます。
+
+4. **URL除外機能**: クエリパラメータやハッシュフラグメント内のURLは、例えば`https://twitter.com/share?url=https://example.com`のような共有リンクなどで、デフォルトでスキップされます。
+
+より多くの設定例については、`examples`ディレクトリを参照してください。
+
+## フィルタオプション
+
+フィルタを使用して、収集するURLを制御できます：
+
+- `domain`: URLドメインと照合する文字列または文字列の配列
+- `pathPrefix`: URLパスと照合する文字列または文字列の配列
+- `regex`: 完全なURLと照合する正規表現パターンまたはパターンの配列
+- `keywords`: URL内のどこかで一致する文字列または文字列の配列
+
+複数のフィルタオブジェクトはOR論理で結合され、単一のフィルタオブジェクト内の条件はAND論理を使用します。
+
+## 結果フォーマット
+
+JSON出力構造には以下が含まれます：
+
+```typescript
+{
+  initialUrl: string;
+  depth: number;
+  allCollectedUrls: string[];
+  linkRelationships: {
+    source: string;
+    found: string;
+  }[];
+  errors: {
+    url: string;
+    errorType: string;
+    message: string;
+  }[];
+  stats: {
+    startTime: string;
+    endTime: string;
+    durationMs: number;
+    totalUrlsScanned: number;
+    totalUrlsCollected: number;
+    maxDepthReached: number;
+  };
+}
+```
+
+## ライセンス
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WebLinkCollector
 
+English | [日本語](./README-ja.md)
+
 A library and CLI tool to recursively collect links from a given initial URL and output them as structured data.
 
 ## Features
@@ -7,6 +9,7 @@ A library and CLI tool to recursively collect links from a given initial URL and
 - Recursively crawl web pages up to a configurable depth (max 5)
 - Extract links from HTML content using CSS selectors
 - Filter URLs by domain, path prefix, regex patterns, and keywords
+- Exclude URLs embedded in query parameters and hash fragments
 - Output results as JSON or plain text
 - Configurable logging levels and request delays
 - Support for configuration via JSON/YAML files
@@ -44,7 +47,7 @@ npm run lint
 Run tests:
 
 ```bash
-npm run test:core
+npm run test
 ```
 
 Build the project:
@@ -58,7 +61,7 @@ npm run build
 | Script              | Description                                   |
 | ------------------- | --------------------------------------------- |
 | `npm run build`     | Compile TypeScript to JavaScript              |
-| `npm run test`      | Run all non-CLI tests                         |
+| `npm run test`      | Run all tests                                 |
 | `npm run test:core` | Run core functionality tests (same as `test`) |
 | `npm run lint`      | Check for linting issues                      |
 | `npm run lint:fix`  | Fix linting issues automatically              |
@@ -95,6 +98,8 @@ web-link-collector --initialUrl https://example.com --depth 2
 | `--output`      | Output file path (if not specified, outputs to stdout)                  | None       |
 | `--format`      | Output format (json, txt)                                               | json       |
 | `--configFile`  | Path to a JSON or YAML configuration file                               | None       |
+| `--skipQuery`   | Skip URLs embedded in query parameters                                  | true       |
+| `--skipHash`    | Skip URLs embedded in hash fragments                                    | true       |
 | `--help`, `-h`  | Show help message                                                       | -          |
 
 ### Examples
@@ -121,6 +126,12 @@ Output results to a text file:
 
 ```bash
 web-link-collector --initialUrl https://example.com --output results.txt --format txt
+```
+
+Disable skipping URLs in query parameters:
+
+```bash
+web-link-collector --initialUrl https://example.com --skipQuery false
 ```
 
 Use a configuration file:
@@ -150,6 +161,8 @@ const results = await collectLinks('https://example.com', {
   selector: '.main-content a',
   delayMs: 2000,
   logLevel: 'info',
+  skipQueryUrls: true, // Skip URLs embedded in query parameters
+  skipHashUrls: true, // Skip URLs embedded in hash fragments
 });
 
 // Access results
@@ -173,6 +186,10 @@ format: json
 # CSS selector to limit link extraction on the initial page
 selector: '.main-content a'
 
+# Skip URLs in query parameters and hash fragments
+skipQueryUrls: true
+skipHashUrls: true
+
 # Filters define which URLs will be collected
 filters:
   # First filter condition (OR logic between filter objects)
@@ -190,6 +207,8 @@ filters:
 2. **CLI vs Configuration Priority**: When both CLI options and a configuration file are provided, the CLI options take precedence. Only CLI options that are explicitly specified will override the configuration file values.
 
 3. **Selector Behavior**: The CSS selector is only applied to the initial page (depth 0) to extract links. Subsequent pages will have all links extracted regardless of the selector.
+
+4. **URL Exclusion**: URLs embedded in query parameters or hash fragments, such as social media share links (e.g., `https://twitter.com/share?url=https://example.com`), are skipped by default.
 
 See the `examples` directory for more configuration examples.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ logLevel: info
 format: json
 
 # CSS selector to limit link extraction on the initial page
-selector: .main-content a
+selector: '.main-content a'
 
 # Filters define which URLs will be collected
 filters:
@@ -182,6 +182,14 @@ filters:
   # Second filter condition
   - domain: api.example.com
 ```
+
+### Important Notes About Configuration Files
+
+1. **YAML Special Characters**: When using special characters in YAML (like `#`, `:`, etc.), you must wrap the value in quotes. For example, use `selector: "#main"` instead of `selector: #main`.
+
+2. **CLI vs Configuration Priority**: When both CLI options and a configuration file are provided, the CLI options take precedence. Only CLI options that are explicitly specified will override the configuration file values.
+
+3. **Selector Behavior**: The CSS selector is only applied to the initial page (depth 0) to extract links. Subsequent pages will have all links extracted regardless of the selector.
 
 See the `examples` directory for more configuration examples.
 

--- a/src/cli/configLoader.ts
+++ b/src/cli/configLoader.ts
@@ -76,8 +76,8 @@ export const mergeConfig = (
 
   // Merge CLI arguments (they take precedence)
   for (const [key, value] of Object.entries(cliArgs)) {
-    // Only override if the CLI argument is explicitly provided (not undefined)
-    if (value !== undefined) {
+    // Only process actual CLI arguments, not yargs internal properties
+    if (key !== '_' && key !== '$0' && !key.startsWith('$')) {
       // For delayMs, if not explicitly set in CLI and available in config file, use config file value
       if (key === 'delayMs' && !isDelayMsExplicitlySet && fileConfig.delayMs !== undefined) {
         console.debug(`Using delayMs from config: ${fileConfig.delayMs}`);

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -123,7 +123,7 @@ export const collectWebLinks = async (params: InitialUrlParams): Promise<Collect
 
     // Fetch the URL content
     logger.debug(`Fetching URL: ${url}`);
-    const result = await fetchUrlContent(url, 0, logger); // delayはcollectLinks内部で処理するため、ここでは0を渡す
+    const result = await fetchUrlContent(url, delayMs, logLevel);
 
     if (!result) {
       // Log error if fetch failed
@@ -143,7 +143,7 @@ export const collectWebLinks = async (params: InitialUrlParams): Promise<Collect
       const useSelector = currentDepth === 0 ? selector : undefined;
 
       // Extract links from the HTML content
-      const links = extractLinksFromHtml(html, finalUrl, useSelector);
+      const links = extractLinksFromHtml(html, finalUrl, useSelector, logger);
       logger.debug(`Extracted ${links.size} links from ${finalUrl}`);
 
       // Process each extracted link sequentially to ensure proper delay between requests

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,7 +8,7 @@ import { LogLevel } from './types';
 /**
  * Interface for a logger object
  */
-interface Logger {
+export interface Logger {
   debug: (message: string, ...args: any[]) => void;
   info: (message: string, ...args: any[]) => void;
   warn: (message: string, ...args: any[]) => void;


### PR DESCRIPTION
## PRの概要
このプルリクエストでは、プロジェクト全体の開発品質と一貫性を向上させるための共通ルールセットの導入、リンク抽出およびフィルタリングロジックの改善（特にクエリパラメータやハッシュフラグメント内のURLの扱い）、そして関連するドキュメントの大幅な更新と日本語版の追加を行いました。

## 変更点
- プロジェクトにおけるテスト方針、コーディングスタイル、URL処理、エラーハンドリング、パフォーマンス考慮事項、コード品質基準、ロギング規約、ドキュメンテーションガイドラインを定義した共通ルールファイル（`.cursor/rules/common.mdc`）が新たに追加されました。
- 日本語版のプロジェクト説明ファイル（`README-ja.md`）が新規に追加されました。
- 英語版の`README.md`が更新され、日本語版へのリンク追加、テスト実行コマンドの修正、CLIオプション（`--skipQuery`, `--skipHash`）の追加、設定ファイルに関する注意書き（YAML特殊文字、オプション優先順位、セレクタの動作、URL除外機能）などが追記されました。
- CLI引数解析処理が改善され、実際にユーザーによって指定されたオプションのみを後続処理に渡すように変更されました。
- CLI引数と設定ファイルのマージロジックが修正され、yargsライブラリ内部で使用されるプロパティが誤ってマージされることを防ぐようになりました。
- リンク収集処理（`src/collector.ts`）において、URLコンテンツ取得関数（`WorkspaceUrlContent`）を呼び出す際に、設定された遅延時間（`delayMs`）とログレベル（`logLevel`）を渡すように変更されました。
- URLコンテンツ取得処理（`src/fetcher.ts`）において、内部的な遅延実行前にデバッグログを出力する機能が追加され、ロガーの生成ロジックが調整されました。また、各種ログメッセージの内容が見直されました。
- URLフィルタリング処理（`src/filter.ts`）に、あるURLが別のURLのクエリパラメータやハッシュフラグメント内に含まれているかを判定する`isUrlInQueryParams`関数が新規追加されました。これに伴い、`isUrlAllowed`関数は、ベースURLをクエリパラメータ等に含むURLをフィルタリングで除外するようになりました。
- `Logger`インターフェースがエクスポートされるようになりました。
- HTMLパーサー（`src/parser.ts`）が改善され、ロガーインスタンスを受け取れるようになり、CSSセレクタ使用時のログ出力が詳細化されました。また、ベースURLをクエリパラメータやハッシュフラグメントに含むURL（例：SNSのシェアリンクなど）を抽出対象から除外するロジックが追加されました。
- URLコンテンツ取得処理およびURLフィルタリング処理、HTMLパーサーに関するテストケースが更新・追加され、新しいロジックやエッジケースのカバレッジが向上しました。