### PR TITLE
:sparkles: feat: Add TypeScript library usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,41 @@ console.log(`Encountered ${results.errors.length} errors`);
 console.log(`Duration: ${results.stats.durationMs}ms`);
 ```
 
+### TypeScript Usage Example
+
+You can also use it with TypeScript. Create a file, for example, `examples/library_usage_example.ts`:
+
+```typescript
+import { collectLinks } from 'web-link-collector'; // Adjust path if necessary, e.g., '../src' for local development
+
+async function main() {
+  try {
+    const results = await collectLinks('https://example.com', {
+      depth: 1,
+    });
+    console.log('Collected links:', results);
+  } catch (error) {
+    console.error('Error occurred:', error);
+  }
+}
+
+main();
+```
+
+To run this TypeScript example, you'll need `ts-node`:
+
+```bash
+# Install ts-node if you haven't already
+npm install -D ts-node
+# or
+# pnpm add -D ts-node
+# or
+# yarn add -D ts-node
+
+# Execute the script
+npx ts-node examples/library_usage_example.ts
+```
+
 ## Configuration Files
 
 You can use JSON or YAML configuration files to specify options. Here's an example:

--- a/examples/library_usage_example.ts
+++ b/examples/library_usage_example.ts
@@ -1,0 +1,18 @@
+// examples/library_usage_example.ts
+import { collectLinks } from '../src';
+
+async function main() {
+  try {
+    const { allCollectedUrls } = await collectLinks('https://takumi-oda.com/blog/', {
+      depth: 2,
+      delayMs: 10,
+      selector: '#list',
+      logLevel: 'debug',
+    });
+    console.log('収集されたリンク:', allCollectedUrls);
+  } catch (error) {
+    console.error('エラーが発生しました:', error);
+  }
+}
+
+main();


### PR DESCRIPTION
Closes #9

This pull request introduces an example of how to use WebLinkCollector as a library within a TypeScript project.

Changes include:
- Addition of `examples/library_usage_example.ts` demonstrating the basic usage of `collectLinks`.
- Update to `README.md` to include the TypeScript example and instructions on how to execute it using `ts-node`.