### PR TITLE
:package: Publish as npm package

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -28,6 +28,20 @@ npm install -g web-link-collector
 npm install web-link-collector
 ```
 
+### CDNからの使用
+
+```html
+<script type="module">
+  import { collectLinks } from 'https://cdn.jsdelivr.net/npm/web-link-collector@1.0.0/dist/index.js';
+
+  // ライブラリの使用例
+  async function main() {
+    const results = await collectLinks('https://example.com', { depth: 1 });
+    console.log(results);
+  }
+</script>
+```
+
 ### 開発環境セットアップ
 
 リポジトリをクローンして依存関係をインストール：
@@ -55,6 +69,26 @@ npm run test
 ```bash
 npm run build
 ```
+
+### npmへの公開
+
+npmに新しいバージョンを公開するには、次の手順に従います：
+
+1. `package.json`のバージョンを更新します：
+
+```bash
+npm version patch  # バグ修正の場合
+npm version minor  # 新機能追加の場合
+npm version major  # 破壊的変更の場合
+```
+
+2. npmに公開：
+
+```bash
+npm publish
+```
+
+パッケージは`prepublishOnly`スクリプトを通じて、公開前に自動的にリントとテストを実行します。
 
 #### 利用可能なスクリプト
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ npm install -g web-link-collector
 npm install web-link-collector
 ```
 
+### Using from CDN
+
+```html
+<script type="module">
+  import { collectLinks } from 'https://cdn.jsdelivr.net/npm/web-link-collector@1.0.0/dist/index.js';
+
+  // Use the library as needed
+  async function main() {
+    const results = await collectLinks('https://example.com', { depth: 1 });
+    console.log(results);
+  }
+</script>
+```
+
 ### Development Setup
 
 Clone the repository and install dependencies:
@@ -55,6 +69,26 @@ Build the project:
 ```bash
 npm run build
 ```
+
+### Publishing to npm
+
+To publish a new version to npm, follow these steps:
+
+1. Update the version in `package.json`:
+
+```bash
+npm version patch  # For bug fixes
+npm version minor  # For new features
+npm version major  # For breaking changes
+```
+
+2. Publish to npm:
+
+```bash
+npm publish
+```
+
+The package will automatically run linting and tests via the `prepublishOnly` script before publishing.
 
 #### Available Scripts
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
@@ -6,10 +6,11 @@ module.exports = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        useESM: false,
+        useESM: true,
       },
     ],
   },
+  extensionsToTreatAsEsm: ['.ts'],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverage: true,

--- a/package.json
+++ b/package.json
@@ -4,15 +4,25 @@
   "description": "A library and CLI tool to recursively collect links from a given initial URL and output them as structured data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "type": "module",
   "bin": {
     "web-link-collector": "dist/bin/web-link-collector.js"
   },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md",
+    "README-ja.md"
+  ],
   "scripts": {
     "build": "tsc",
+    "postbuild": "chmod +x dist/bin/web-link-collector.js",
     "test": "jest --testPathIgnorePatterns=\"tests/cli\"",
     "test:core": "jest tests/filter.test.ts tests/logger.test.ts tests/parser.test.ts tests/fetcher.test.ts",
     "start": "node dist/bin/web-link-collector.js",
     "prepare": "husky",
+    "prepublishOnly": "npm run check && npm run build",
+    "postversion": "git push && git push --tags",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "format": "prettier --write 'src/**/*.ts' 'bin/**/*.ts' 'tests/**/*.ts'",
@@ -25,7 +35,7 @@
     "collector",
     "cli"
   ],
-  "author": "",
+  "author": "xiaotiantakumi",
   "license": "MIT",
   "dependencies": {
     "cheerio": "^1.0.0-rc.12",
@@ -53,5 +63,12 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/xiaotiantakumi/WebLinkCollector.git"
+  },
+  "bugs": {
+    "url": "https://github.com/xiaotiantakumi/WebLinkCollector/issues"
+  },
+  "homepage": "https://github.com/xiaotiantakumi/WebLinkCollector#readme",
+  "engines": {
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
## Changes

This PR prepares WebLinkCollector to be published as an npm package.

### Key Changes

- Added necessary configurations to package.json:
  - Added `files` field to specify files included in the package
  - Added `prepublishOnly`, `postversion`, and `postbuild` scripts
  - Added metadata (author, bugs, homepage, engines)
  - Added `type: "module"` for ESM support

- Updated README:
  - Added information about using the package from CDN
  - Added instructions for publishing to npm

- Updated Jest configuration for ESM support

### Testing

- Confirmed all tests pass
- Ran `npm publish --dry-run` to verify package contents

This completes the work for Issue #6 "Publish as npm package".