### PR TITLE
Fix incorrect TypeScript types path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A library and CLI tool to recursively collect links from a given initial URL and output them as structured data",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "type": "module",
   "bin": {
     "web-link-collector": "dist/bin/web-link-collector.js"


### PR DESCRIPTION
## ??
TypeScript??????????????????????????????????????????????????????????????

## ????
package.json?`types`?????????????
- ???: `"types": "dist/index.d.ts"`
- ???: `"types": "dist/src/index.d.ts"`

## ????
- `npm run build`??????????????
- ???????????????`dist/src/index.d.ts`??????????????

## ????
- ???????????????????????????????????????????TypeScript??????????????????????????

Fixes #13