### PR TITLE
Fix incorrect TypeScript types path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A library and CLI tool to recursively collect links from a given initial URL and output them as structured data",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "type": "module",
   "bin": {
     "web-link-collector": "dist/bin/web-link-collector.js"


### PR DESCRIPTION
## Problem
The TypeScript type definitions are not properly loaded when using this package as a dependency. This is because the 'types' field in package.json points to an incorrect path.

## Changes
Updated the `types` field in package.json:
- Before: `"types": "dist/index.d.ts"`
- After: `"types": "dist/src/index.d.ts"`

## How to Verify
- Run `npm run build`
- Confirm that the type definition file exists at `dist/src/index.d.ts`

## Impact
- Package users will no longer need to manually create type definition files as TypeScript will automatically find and use the correct type definitions.

Fixes #13