### PR TITLE
Fix module resolution path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "web-link-collector",
   "version": "1.0.1",
   "description": "A library and CLI tool to recursively collect links from a given initial URL and output them as structured data",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Problem
The main entry point in package.json points to a non-existent file, causing module resolution errors when importing the package.

## Changes
Updated the `main` field in package.json:
- Before: `"main": "dist/index.js"`
- After: `"main": "dist/src/index.js"`

## How to Verify
- Run `npm run build`
- Create a test file that imports from the package
- Verify that the import works without errors

## Impact
- This change fixes the module import errors when using the package as a dependency
- Aligns with the actual file structure created by the TypeScript compiler

Fixes #19