### PR TITLE
Fix module type configuration for proper import resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A library and CLI tool to recursively collect links from a given initial URL and output them as structured data",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
-  "type": "module",
   "bin": {
     "web-link-collector": "dist/bin/web-link-collector.js"
   },


### PR DESCRIPTION
## Problem
The package has a module format mismatch that causes import failures:
- `package.json` declares `\"type\": \"module\"` (ESM)
- But the compiled JavaScript uses CommonJS format

## Changes
- Removed `\"type\": \"module\"` from package.json to configure the package properly as CommonJS
- This matches the existing codebase which uses CommonJS style imports
- Keeps the TypeScript configuration as-is with CommonJS output

## How to Verify
- Run `npm run build`
- Create a test file that imports from the package
- Verify that the import works without errors in both CommonJS and ESM projects

## Impact
- Fixes the module import errors when using the package as a dependency
- Makes the package configuration consistent with its actual implementation

Fixes #21